### PR TITLE
Avoid modifying global match data in string matching

### DIFF
--- a/literate-calc-mode.el
+++ b/literate-calc-mode.el
@@ -88,24 +88,25 @@ an overlay.
 Returns 'nil' if the line is not a calc expression.
 Returns 'nil' if the result is not bound to a name.
 Returns a list of (NAME RESULT) if the result is bound to a name."
-  (when (string-match-p literate-calc--expression line)
-    (let* ((whole-line (s-split "=" line))
-           (var-name (string-trim (car whole-line)))
-           (var-value (string-trim (cadr whole-line)))
-           (resolved-value (cl-reduce (lambda (s kv)
-                                        (let ((k (car kv))
-                                              (v (cadr kv)))
-                                          (s-replace k (format "(%s)" v) s)))
-                                      variable-scope
-                                      :initial-value var-value))
-           (var-result (if (string-empty-p resolved-value)
-                           "0"
-                         (format "%s" (calc-eval resolved-value)))))
-      (if insert
-          (literate-calc--insert-result var-name var-result)
-          (literate-calc--create-overlay var-name var-result))
-      (unless (string-empty-p var-name)
-        (list var-name var-result)))))
+  (save-match-data
+    (when (string-match-p literate-calc--expression line)
+      (let* ((whole-line (s-split "=" line))
+             (var-name (string-trim (car whole-line)))
+             (var-value (string-trim (cadr whole-line)))
+             (resolved-value (cl-reduce (lambda (s kv)
+                                          (let ((k (car kv))
+                                                (v (cadr kv)))
+                                            (s-replace k (format "(%s)" v) s)))
+                                        variable-scope
+                                        :initial-value var-value))
+             (var-result (if (string-empty-p resolved-value)
+                             "0"
+                           (format "%s" (calc-eval resolved-value)))))
+        (if insert
+            (literate-calc--insert-result var-name var-result)
+            (literate-calc--create-overlay var-name var-result))
+        (unless (string-empty-p var-name)
+          (list var-name var-result))))))
 
 ;;;###autoload
 (defun literate-calc-clear-overlays ()

--- a/literate-calc-mode.el
+++ b/literate-calc-mode.el
@@ -88,7 +88,7 @@ an overlay.
 Returns 'nil' if the line is not a calc expression.
 Returns 'nil' if the result is not bound to a name.
 Returns a list of (NAME RESULT) if the result is bound to a name."
-  (when (string-match literate-calc--expression line)
+  (when (string-match-p literate-calc--expression line)
     (let* ((whole-line (s-split "=" line))
            (var-name (string-trim (car whole-line)))
            (var-value (string-trim (cadr whole-line)))
@@ -187,8 +187,8 @@ handler for `after-change-functions'."
             (overlays-in (line-beginning-position) (line-end-position))
             (save-excursion
               (goto-char beg)
-              (string-match literate-calc--expression
-                            (thing-at-point 'line))))
+              (string-match-p literate-calc--expression
+                              (thing-at-point 'line))))
     (literate-calc-eval-buffer)))
 
 (defun literate-calc--exit ()


### PR DESCRIPTION
`string-match` has the side-effect of modifying the editor's global match data. Since the implementation doesn't access match data, it should be save to use `string-match-p` instead, which is side-effect free. 

This change appears to resolve issues with org-mode, where literate-calc-mode interferes with org's own match data usage.

Resolves #5.