### PR TITLE
Inhibit calculations in inline LaTeX

### DIFF
--- a/README.org
+++ b/README.org
@@ -53,10 +53,10 @@ the following options:
 The idle time prevents lag due to constant recalculation in the middle
 of typing, defaulting to 1 second.
 
-There is currently a single inhibitor, which comes installed by
-default:
+These are the available inhibitors, which are all enabled by default:
 
 - ~literate-calc-mode-inhibit-in-src-blocks~ :: Prevents evaluation inside org-mode ~src~ blocks
+- ~literate-calc-mode-inhibit-in-latex~ :: Prevents evaluation inside org-mode LaTeX fragments
 
 Of course you can also just ~setq~ the options directly.
 

--- a/literate-calc-mode.el
+++ b/literate-calc-mode.el
@@ -47,7 +47,9 @@
   :group 'editing
   :prefix "literate-calc-mode-")
 
-(defcustom literate-calc-mode-inhibit-line-functions '(literate-calc-mode-inhibit-in-src-blocks)
+(defcustom literate-calc-mode-inhibit-line-functions
+  '(literate-calc-mode-inhibit-in-src-blocks
+    literate-calc-mode-inhibit-in-latex)
   "Hook functions called for each line to test whether to inhibit calculation.
 
 If any of these functions returns non-nil, overlays will not be displayed."
@@ -81,6 +83,12 @@ buffers larger than this, as measured by `buffer-size'."
   (and (derived-mode-p #'org-mode)
        (memq (org-element-type (org-element-context))
              '(inline-src-block src-block))))
+
+(defun literate-calc-mode-inhibit-in-latex ()
+  "Return non-nil if point is in a latex fragment or environment."
+  (and (derived-mode-p #'org-mode)
+       (memq (org-element-type (org-element-context))
+             '(latex-fragment latex-environment))))
 
 (defvar-local literate-calc-minor-mode nil)
 (defvar-local literate-calc--scope (list))


### PR DESCRIPTION
This is very likely not what the user expects, so we can default to inhibiting in both inline blocks ($latex$) and environments ( \begin{equation}
latex
\end{equation}
).

Fixes #33.