### PR TITLE
Only block variable expansion for longer overlapping function names

### DIFF
--- a/literate-calc-mode.el
+++ b/literate-calc-mode.el
@@ -4,7 +4,7 @@
 ;; Maintainer: Robin Schroer
 ;; Version: 0.1
 ;; Homepage: https://github.com/sulami/literate-calc-mode.el
-;; Package-Requires: ((emacs "25.1") (s "1.12.0"))
+;; Package-Requires: ((emacs "25.1") (dash "2.19.1") (s "1.12.0"))
 ;; Keywords: calc, languages, tools
 
 
@@ -33,6 +33,7 @@
 (require 'calc)
 (require 'calc-prog)
 (require 'cl-lib)
+(require 'dash)
 (require 'ob)
 (require 'org-element)
 (require 'rx)
@@ -176,14 +177,18 @@ NAME should be an empty string if RESULT is not bound."
   "Replace all occurrences of K in S with V.
 
 If an occurrence happens inside any reserved name, as matched by
-`literate-calc--reserved-names-rx', do not replace it."
+`literate-calc--reserved-names-rx', do not replace it if the
+variable name is shorter than the function name."
   (let ((looking-at 0))
     (while (and (< looking-at (length s))
                 (string-match k s looking-at))
       (let ((match-start (match-beginning 0))
             (match-end (match-end 0))
-            (reserved-positions (s-matched-positions-all literate-calc--reserved-names-rx
-                                                         s)))
+            (reserved-positions (-filter (lambda (pos)
+                                           (<= (length k)
+                                               (- (cdr pos) (car pos))))
+                                         (s-matched-positions-all literate-calc--reserved-names-rx
+                                                                  s))))
         (setq looking-at match-end)
         (when (cl-notany (lambda (pos)
                            (or (<= (car pos) match-start (cdr pos))

--- a/test/deps.el
+++ b/test/deps.el
@@ -36,6 +36,7 @@
   (load bootstrap-file nil 'nomessage))
 
 (straight-use-package 'ert-junit)
+(straight-use-package 'dash)
 (straight-use-package 's)
 
 ;;; deps.el ends here

--- a/test/literate-calc-mode-test.el
+++ b/test/literate-calc-mode-test.el
@@ -225,12 +225,25 @@
       (literate-calc-minor-mode)
       (should (not literate-calc-minor-mode)))))
 
-(ert-deftest literate-calc-mode-test/overlapping-names-test ()
+;; If in a function, don't expand variable names to avoid clobbering
+;; the function.
+(ert-deftest literate-calc-mode-test/variables-overlapping-longer-function-names-test ()
   (with-temp-buffer
     (literate-calc-mode)
     (insert "s = sqrt(25)\n= sqrt(25)")
     (literate-calc-insert-results)
     (should (equal "s = sqrt(25) => s: 5\n= sqrt(25) => 5"
+                   (buffer-string)))))
+
+(ert-deftest literate-calc-mode-test/variables-overlapping-shorter-function-names-test ()
+  "If a variable name overlaps with a function name, in this case
+`year', still expand the variable if it's longer than the
+function."
+  (with-temp-buffer
+    (literate-calc-mode)
+    (insert "yearly = 25\n= yearly * 2")
+    (literate-calc-insert-results)
+    (should (equal "yearly = 25 => yearly: 25\n= yearly * 2 => 50"
                    (buffer-string)))))
 
 (provide 'literate-calc-mode-test)


### PR DESCRIPTION
The fix for #15 blocked variable expansion for cases where a variable name would overlap with a builtin function. This works, but introduced a new problem when a variable name is overlapped by a shorter builtin function, such as `year`.

With this change the longer name will take precedence, with builtin functions taking precedence for equal length.

Fixes #36.