### PR TITLE
Add command to evaluate a region

### DIFF
--- a/literate-calc-mode.el
+++ b/literate-calc-mode.el
@@ -290,6 +290,13 @@ If BUFFER is set, run in it, otherwise in `current-buffer'."
             (forward-line 1)))))))
 
 ;;;###autoload
+(defun literate-calc-eval-region ()
+    (interactive)
+    (save-restriction
+      (narrow-to-region (region-beginning) (region-end))
+      (literate-calc-eval-buffer)))
+
+;;;###autoload
 (defun literate-calc-insert-results ()
   "Insert results into buffer instead of creating overlays."
   (interactive)


### PR DESCRIPTION
This pull requests adds a command to evaluate a region similar to the existing commands to evaluate line and to evaluate the whole buffer. 

I have been using this function in my own Emacs installation for some time now and it has become my preferred way of using this wonderful package
