### PR TITLE
Require Emacs 27

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,6 @@
 version: 2.1
 
 executors:
-  emacs-25:
-    docker:
-      - image: silex/emacs:25.2-alpine-ci
-  emacs-26:
-    docker:
-      - image: silex/emacs:26-alpine-ci
   emacs-27:
     docker:
       - image: silex/emacs:27-alpine-ci
@@ -46,8 +40,6 @@ workflows:
           matrix:
             parameters:
               executor:
-                - emacs-25
-                - emacs-26
                 - emacs-27
                 - emacs-28
                 - emacs-29

--- a/literate-calc-mode.el
+++ b/literate-calc-mode.el
@@ -4,7 +4,7 @@
 ;; Maintainer: Robin Schroer
 ;; Version: 0.1
 ;; Homepage: https://github.com/sulami/literate-calc-mode.el
-;; Package-Requires: ((emacs "25.1") (dash "2.19.1") (s "1.12.0"))
+;; Package-Requires: ((emacs "27") (dash "2.19.1") (s "1.12.0"))
 ;; Keywords: calc, languages, tools
 
 


### PR DESCRIPTION
We're now using :local in defcustom, which isn't available before 27.